### PR TITLE
Add option to select firewalld zone

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,16 @@ This role configures only secure algorithms by default in order to have
 authentication code algorithms that this role defines by defaults. See
 `vars/*.yml` for details.
 
+### ssh_firewalld_zone
+
+    ssh_firewalld_zone: ''
+
+This role can optionally configure a specific firewalld zone
+(if `ssh_manage_firewall` is `true`) for which the ssh service is allowed.
+By default the zone is omitted and the firewalld defaults used.
+See [firewalld documentation](https://firewalld.org/documentation/zone/default-zone.html)
+for details.
+
 ## Example Playbook
 
 Including an example of how to use your role (for instance, with variables

--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ authentication code algorithms that this role defines by defaults. See
 
 This role can optionally configure a specific firewalld zone
 (if `ssh_manage_firewall` is `true`) for which the ssh service is allowed.
-By default the zone is omitted and the firewalld defaults used.
+By default the zone is omitted and the firewalld defaults are used.
 See [firewalld documentation](https://firewalld.org/documentation/zone/default-zone.html)
 for details.
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -43,3 +43,6 @@ ssh_crypto_hostkey_algos: []
 ssh_crypto_kex_algos: []
 ssh_crypto_ciphers: []
 ssh_crypto_macs: []
+
+## Firewalld-related configuration options
+ssh_firewalld_zone: ''

--- a/tasks/firewall.yml
+++ b/tasks/firewall.yml
@@ -13,4 +13,5 @@
     service: ssh
     permanent: true
     immediate: true
+    zone: "{{ ssh_firewalld_zone | default(omit, true) }}"
     state: enabled


### PR DESCRIPTION
Fix #6

This add the option to set the firewalld zone in which the ssh service should be mananged.
This option is only used if this role is configured to manage the firewall.

The default behavior doesn't change. Without any modifications this role configures the ssh
service in the public (default) zone. This is current behavior.

This is a new feature without any breaking changes.
